### PR TITLE
Fix Namespace

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "autoload": {
         "files": [ "registration.php" ],
         "psr-4": {
-          "Trive\\Revo\\": ""
+          "Trive\\AdaptiveResize\\": ""
         }
     }
 


### PR DESCRIPTION
The namespace was (presumably) referencing something older prior to being open-sourced.

Just updated this so it can be installed nicely via Composer.