### PR TITLE
remove origin resize in order to keep image quality

### DIFF
--- a/Helper/Image.php
+++ b/Helper/Image.php
@@ -144,9 +144,6 @@ class Image extends \Magento\Catalog\Helper\Image
             if ($this->_scheduleRotate) {
                 $model->rotate($this->getAngle());
             }
-            if ($this->_scheduleResize) {
-                $model->resize();
-            }
             if ($this->_cropPosition) {
                 $this->_getModel()->setCropPosition($this->_cropPosition);
             }


### PR DESCRIPTION
If you resize first and call `$model->adaptiveResize()` after magento will adaptiveResize() the resized image. This significantly reduces the image Quality.